### PR TITLE
Internationalization

### DIFF
--- a/app/MenuHelper.js
+++ b/app/MenuHelper.js
@@ -82,7 +82,11 @@ function assignMenu() {
             {
                 label: _('menu::view::devTools'),
                 accelerator: 'F12',
-                click() {mainWindow.webContents.toggleDevTools();}
+                click() {
+                    for(let i = 0; i < global.windows.length; i++) {
+                        global.windows[i].toggleDevTools();
+                    }
+                }
             },
             {type: 'separator'},
             {
@@ -155,7 +159,11 @@ function assignMenu() {
                 }
             ]
         }
-    ]
+    ];
+
+    if(process.platform === 'darwin') {
+        menuTemplate.unshift({});
+    }
 
     let menu = Menu.buildFromTemplate(menuTemplate);
     Menu.setApplicationMenu(menu);

--- a/app/MenuHelper.js
+++ b/app/MenuHelper.js
@@ -3,6 +3,7 @@ const {app, Menu, remote} = electron;
 const Config = require('electron-config');
 const _ = require('./i18n/_i18n');
 const langs = require('./i18n/_langs.json');
+const MarkdownGuideWindow = require('./MarkdownGuideWindow');
 
 let config = new Config();
 
@@ -148,7 +149,7 @@ function assignMenu() {
                     role: 'about'
                 },
                 {
-                    label: _('menu::view::markdownGuide'),
+                    label: _('menu::help::markdownGuide'),
                     accelerator: 'F1',
                     click() {openMarkdownGuide();}
                 }
@@ -209,6 +210,26 @@ function swapTheme(id) {
     global.windows.forEach(win => {
         win.webContents.send('SWAP_THEME', id);
     })
+}
+
+/**
+ * Opens the Markdown Guide window.
+ * Opens a new guide window if none are open, or reshows the guide window if it's already open.
+ */
+function openMarkdownGuide() {
+    if(global.markdownGuide == null) {
+        global.markdownGuide = new MarkdownGuideWindow();
+        global.markdownGuide.on('close', () => {
+            markdownGuide = null;
+            global.windows.splice(global.windows.indexOf(markdownGuide), 1);
+        })
+        global.markdownGuide.setMenu(null);
+        global.windows.push(markdownGuide);
+    }
+    else {
+        markdownGuide.webContents.reloadIgnoringCache();
+        markdownGuide.show();
+    }
 }
 
 module.exports = {

--- a/app/MenuHelper.js
+++ b/app/MenuHelper.js
@@ -172,6 +172,7 @@ function getLanguagesSubmenu() {
         let l = langs[i];
         langsSubmenu.push({
             label: l.label,
+            sublabel: _(`langs::${l.id}`),
             type: 'radio',
             checked: l.id === config.get('lang'),
             click() {toggleLanguage(l.id);}

--- a/app/MenuHelper.js
+++ b/app/MenuHelper.js
@@ -123,7 +123,7 @@ function assignMenu() {
                 submenu: getLanguagesSubmenu()
             },
             {
-                label: _('menu::view::resetZoom'),
+                label: _('menu::view::actualSize'),
                 role: 'resetzoom'
             },
             {

--- a/app/MenuHelper.js
+++ b/app/MenuHelper.js
@@ -1,0 +1,217 @@
+const electron = require('electron');
+const {app, Menu, remote} = electron;
+const Config = require('electron-config');
+const _ = require('./i18n/_i18n');
+const langs = require('./i18n/_langs.json');
+
+let config = new Config();
+
+/**
+ * Generates and set the new menu from a template.
+ */
+function assignMenu() {
+    const menuTemplate = [
+        {
+            label: _('menu::file'),
+            submenu: [
+                {
+                    label: _('menu::file::new'),
+                    accelerator: 'CommandOrControl+N',
+                    click() {newFile();}
+                },
+                {
+                    label: _('menu::file::open'),
+                    accelerator: 'CommandOrControl+O',
+                    click() {openFile();}
+                },
+                {type: 'separator'},
+                {
+                    label: _('menu::file::save'),
+                    accelerator: 'CommandOrControl+S',
+                    click() {save();}
+                },
+                {
+                    label: _('menu::file::saveAs'),
+                    accelerator: 'CommandOrControl+Shift+S',
+                    click() {saveAs();}
+                }
+            ]
+        },
+        {
+            label: _('menu::edit'),
+            submenu: [
+                {
+                    label: _('menu::edit::undo'),
+                    role: 'undo'
+                },
+                {
+                    label: _('menu::edit::redo'),
+                    role: 'redo'
+                },
+                {type: 'separator'},
+                {
+                    label: _('menu::edit::cut'),
+                    role: 'cut'
+                },
+                {
+                    label: _('menu::edit::copy'),
+                    role: 'copy'
+                },
+                {
+                    label: _('menu::edit::paste'),
+                    role: 'paste'
+                },
+                {
+                    label: _('menu::edit::selectAll'),
+                    role: 'selectall'
+                }
+            ]
+        },
+        {
+          label: _('menu::view'),
+          submenu: [
+            {
+                label: _('menu::view::reload'),
+                role: 'reload'
+            },
+            {
+                label: _('menu::view::forceReload'),
+                role: 'forcereload'
+            },
+            {
+                label: _('menu::view::devTools'),
+                accelerator: 'F12',
+                click() {mainWindow.webContents.toggleDevTools();}
+            },
+            {type: 'separator'},
+            {
+                label: _('menu::view::theme'),
+                submenu: [
+                    {
+                        label: 'Dark',
+                        id: 'DARK',
+                        type: 'radio',
+                        checked: isTheme('DARK'),
+                        click() {swapTheme('DARK');}
+                    },
+                    {
+                        label: 'Light',
+                        id: 'LIGHT',
+                        type: 'radio',
+                        checked: isTheme('LIGHT'),
+                        click() {swapTheme('LIGHT');}
+                    },
+                    {
+                        label: 'GitHub Dark',
+                        id: 'GITHUB_DARK',
+                        type: 'radio',
+                        checked: isTheme('GITHUB_DARK'),
+                        click() {swapTheme('GITHUB_DARK');}
+                    },
+                    {
+                        label: 'GitHub Light',
+                        id: 'GITHUB',
+                        type: 'radio',
+                        checked: isTheme('GITHUB'),
+                        click() {swapTheme('GITHUB');}
+                    }
+                ]
+            },
+            {
+                label: _('menu::view::setLanguage'),
+                submenu: getLanguagesSubmenu()
+            },
+            {
+                label: _('menu::view::resetZoom'),
+                role: 'resetzoom'
+            },
+            {
+                label: _('menu::view::zoomIn'),
+                role: 'zoomin'
+            },
+            {
+                label: _('menu::view::zoomOut'),
+                role: 'zoomout'
+            },
+            {type: 'separator'},
+            {
+                label: _('menu::view::fullScreen'),
+                role: 'togglefullscreen'
+            }
+          ]
+        },
+        {
+            label: _('menu::help'),
+            submenu: [
+                {
+                    label: _('menu::help::about'),
+                    role: 'about'
+                },
+                {
+                    label: _('menu::view::markdownGuide'),
+                    accelerator: 'F1',
+                    click() {openMarkdownGuide();}
+                }
+            ]
+        }
+    ]
+
+    let menu = Menu.buildFromTemplate(menuTemplate);
+    Menu.setApplicationMenu(menu);
+}
+
+/**
+ * Compiles the languages submenu.
+ * Generates the languages submenu dynamically from `/i18n/_langs.json`
+ * @returns A submenu of menu items representing each supported language.
+ */
+function getLanguagesSubmenu() {
+    let langsSubmenu = [];
+    for (let i = 0; i < langs.length; i++) {
+        let l = langs[i];
+        langsSubmenu.push({
+            label: l.label,
+            type: 'radio',
+            checked: l.id === config.get('lang'),
+            click() {toggleLanguage(l.id);}
+        })
+    }
+    return langsSubmenu;
+}
+
+/**
+ * Configures the application to switch languages.
+ * @param {string} id - The language code of the new language.
+ */
+function toggleLanguage(id) {
+    if(config.get('lang') === id) {return;}
+    config.set('lang', id);
+    assignMenu();
+}
+
+/**
+ * Determines whether a theme is the current theme.
+ * Used to set the initial radio selection for the theme menu from config.
+ * @param {string} id - The theme ID (an ID of `FOO` will use the `theme_FOO` CSS file).
+ * @returns {boolean} Whether the given ID matches the theme config.
+ */
+function isTheme(id) {
+    return id == config.get('theme');
+}
+
+/**
+ * Alerts all active windows to change their theme.
+ * Also sets the theme in config.
+ * @param {string} id - The theme ID to switch to (an ID of `FOO` will use the `theme_FOO` CSS file).
+ */
+function swapTheme(id) {
+    config.set('theme', id);
+    global.windows.forEach(win => {
+        win.webContents.send('SWAP_THEME', id);
+    })
+}
+
+module.exports = {
+    assignMenu,
+    swapTheme
+};

--- a/app/css/theme_DARK.css
+++ b/app/css/theme_DARK.css
@@ -41,8 +41,8 @@ body {
 }
 
 .mdfile {
-    color: orange;
-    text-shadow: 1px 1px 1px orange;
+    color: #bbb;
+    text-shadow: 1px 1px 1px #bbb;
 }
 
 .txtfile {
@@ -53,6 +53,11 @@ body {
 .otherfile {
     color: #777;
     text-shadow: 1px 1px 1px #777;
+}
+
+.tree-item:hover {
+    background-color: #333;
+    width: 100%;
 }
 
 .row {

--- a/app/css/theme_GITHUB.css
+++ b/app/css/theme_GITHUB.css
@@ -9,6 +9,50 @@ body, html {
     /* text-shadow: 1px 1px 1px #111; */
 }
 
+#directory-pane {
+    background-color: #24292e;
+}
+
+.tree-item:hover {
+    background-color: #333;
+    width: 100%;
+}
+
+.parent-dir {
+    color: #777;
+    text-shadow: 1px 1px 1px #777;
+}
+
+.parent-dir::before {
+    color: #777 !important;
+    text-shadow: 1px 1px 1px black;
+}
+
+.subdir {
+    color: #bbb;
+    text-shadow: 1px 1px 1px #bbb;
+}
+
+.subdir::before {
+    color: khaki;
+    text-shadow: 1px 1px 1px black;
+}
+
+.mdfile {
+    color: #bbb;
+    text-shadow: 1px 1px 1px #bbb;
+}
+
+.txtfile {
+    color: #999;
+    text-shadow: 1px 1px 1px #999;
+}
+
+.otherfile {
+    color: #777;
+    text-shadow: 1px 1px 1px #777;
+}
+
 #preview-pane {
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;

--- a/app/css/theme_LIGHT.css
+++ b/app/css/theme_LIGHT.css
@@ -30,6 +30,11 @@ body {
     background-color: #ccccd7;
 }
 
+.tree-item:hover {
+    background-color: #eee;
+    width: 100%;
+}
+
 .parent-dir {
     color: #0074D9 !important;
     text-shadow: 1px 1px 1px #0074D9;

--- a/app/editor.js
+++ b/app/editor.js
@@ -159,6 +159,7 @@ function loadDirectory(dir) {
     up.innerHTML = '..';
     up.onclick = () => {loadDirectory(parent);}
     up.classList.add('subdir');
+    up.classList.add('tree-item');
     up.classList.add('parent-dir');
     tree.appendChild(up);
     fs.readdir(dir, (err, files) => {
@@ -168,6 +169,7 @@ function loadDirectory(dir) {
                 let dirRecord = document.createElement('li');
                 dirRecord.innerHTML = file;
                 dirRecord.onclick = () => {loadDirectory(path.join(dir, file));}
+                dirRecord.classList.add('tree-item');
                 dirRecord.classList.add('subdir');
                 tree.appendChild(dirRecord);
             }
@@ -183,6 +185,7 @@ function loadDirectory(dir) {
                         setEditorContents(data);
                     })
                 }
+                fileRecord.classList.add('tree-item');
                 fileRecord.classList.add('treefile');
                 if(MARKDOWN_EXTENSIONS.indexOf(path.extname(file)) > -1) {
                     fileRecord.classList.add('mdfile');

--- a/app/i18n/_i18n.js
+++ b/app/i18n/_i18n.js
@@ -6,6 +6,7 @@ let langs = require('./_langs.json');
 let config = new Config();
 let currentLangCode = config.get('lang') === undefined ? 'enUS' : config.get('lang');
 let lang = require(`./${getLangSource()}`);
+let enUS = require('./enUS.json');
 
 /**
  * Gets the localization of a string.
@@ -22,6 +23,30 @@ function _(key) {
 
     let tokens = key.split('::');
     let localized = lang;
+    for (let i = 0; i < tokens.length; i++) {
+        localized = localized[tokens[i]];
+        if(localized === undefined) {
+            // If the key is not found in the language, use an English fallback
+            // If all hope is lost, return most specific token
+            return currentLangCode !== 'enUS' ? fallback(key) : tokens[tokens.length - 1];
+        }
+    }
+    if((typeof localized) === 'object') {
+        return localized.label === undefined ? fallback(key) : localized.label;
+    }
+    else {
+        return localized;
+    }
+}
+
+/**
+ * Gets a fallback string in English (US).
+ * @param {string} key - The key of the localized string, in double-colon notation.
+ * @returns The *English (US)* localization of the keyed string, or the most specific identifier of the key if no localization exists.
+ */
+function fallback(key) {
+    let tokens = key.split('::');
+    let localized = enUS;
     for (let i = 0; i < tokens.length; i++) {
         localized = localized[tokens[i]];
         if(localized === undefined) {

--- a/app/i18n/_i18n.js
+++ b/app/i18n/_i18n.js
@@ -1,0 +1,41 @@
+const electron = require('electron');
+const Config = require('electron-config');
+
+let langs = require('./_langs.json');
+
+let config = new Config();
+let currentLangCode = config.get('lang') === undefined ? 'enUS' : config.get('lang');
+let lang = require(`./${getLangSource()}`);
+
+function _(key) {
+    // Re-cache lang if config lang has been updated
+    if(config.get('lang') !== currentLangCode) {
+        currentLangCode = config.get('lang');
+        lang = require(`./${getLangSource()}`);
+    }
+
+    let tokens = key.split('::');
+    let localized = lang;
+    for (let i = 0; i < tokens.length; i++) {
+        localized = localized[tokens[i]];
+        if(localized === undefined) {
+            // If all hope is lost, return most specific token
+            return tokens[tokens.length - 1];
+        }
+    }
+    if((typeof localized) === 'object') {
+        return localized.label === undefined ? tokens[tokens.length - 1] : localized.label;
+    }
+    else {
+        return localized;
+    }
+}
+
+function getLangSource() {
+    let currentLang = langs.find((l) => {
+        return l.id == currentLangCode;
+    });
+    return currentLang.src;
+}
+
+module.exports = _;

--- a/app/i18n/_i18n.js
+++ b/app/i18n/_i18n.js
@@ -7,6 +7,12 @@ let config = new Config();
 let currentLangCode = config.get('lang') === undefined ? 'enUS' : config.get('lang');
 let lang = require(`./${getLangSource()}`);
 
+/**
+ * Gets the localization of a string.
+ * Uses the current language code in config.
+ * @param {string} key - The key of the localized string, in double-colon notation.
+ * @return The localization of the keyed string, or the most specific identifier of the key if no localization exists.
+ */
 function _(key) {
     // Re-cache lang if config lang has been updated
     if(config.get('lang') !== currentLangCode) {
@@ -31,6 +37,10 @@ function _(key) {
     }
 }
 
+/**
+ * Determines the source file of the current language.
+ * @returns The name of the JSON lang file associated with the lang code in config.
+ */
 function getLangSource() {
     let currentLang = langs.find((l) => {
         return l.id == currentLangCode;

--- a/app/i18n/_langs.json
+++ b/app/i18n/_langs.json
@@ -1,0 +1,12 @@
+[
+    {
+        "label": "English (US)",
+        "id": "enUS",
+        "src": "enUS.json"
+    },
+    {
+        "label": "Igpay Atinlay",
+        "id": "igpay",
+        "src": "igpay.json"
+    }
+]

--- a/app/i18n/_langs.json
+++ b/app/i18n/_langs.json
@@ -8,5 +8,10 @@
         "label": "Igpay Atinlay",
         "id": "igpay",
         "src": "igpay.json"
+    },
+    {
+        "label": "LOLCAT",
+        "id": "lolcat",
+        "src": "lolcat.json"
     }
 ]

--- a/app/i18n/enUS.json
+++ b/app/i18n/enUS.json
@@ -33,5 +33,10 @@
             "about": "About Markfast",
             "markdownGuide": "Markdown Guide"
         }
+    },
+    "langs": {
+        "enUS": "English (US)",
+        "igpay": "Pig Latin",
+        "lolcat": "Lolcat"
     }
 }

--- a/app/i18n/enUS.json
+++ b/app/i18n/enUS.json
@@ -38,5 +38,45 @@
         "enUS": "English (US)",
         "igpay": "Pig Latin",
         "lolcat": "Lolcat"
+    },
+    "mdg": {
+        "markdown": "Markdown",
+        "presentation": "Presentation",
+        "hotkeys": "Hotkeys",
+        "header": "Your Guide to Markdown",
+        "desc": "<a href=\"https://daringfireball.net/projects/markdown/\" title=\"The official website of the Markdown language\">Markdown</a> is a markup language designed to be legible and easy to convert to HTML. The Markfast editor is currently using the <a href=\"http://spec.commonmark.org/0.28/\" title=\"CommonMark Spec Version 0.28\">CommonMark Spec v0.28</a>. The following is a guide to Markdown's syntax.",
+        "toc": "Table of Contents",
+        "inlineHTML": {
+            "label": "Inline HTML",
+            "desc": "Inline HTML tags are parsed as HTML, meaning they can be used to structure a Markdown document. For instance, to format some text as inline code, you could use Markdown's native method of placing a backtick at each end of the inline code, or you could wrap the inline code in <code>&lt;code&gt;</code> tags.",
+            "sample": "Inline code"
+        },
+        "headings": {
+            "label": "Headings",
+            "desc": "To use HTML <code>h1</code>-<code>h6</code> headings, use pound signs at the start of the line. For instance, use <code>#</code> for <code>h1</code>, <code>##</code> for <code>h2</code>, and so forth up to <code>######</code> for <code>h6</code>.",
+            "sample": {
+                "1": "Heading 1",
+                "2": "Heading 2",
+                "3": "Heading 3",
+                "4": "Heading 4",
+                "5": "Heading 5",
+                "6": "Heading 6"
+            }
+        },
+        "emphasis": {
+            "label": "Emphasis",
+            "desc": "",
+            "sample": {
+                "bold": {
+                    "1": "This is bold.",
+                    "2": "This is also bold."
+                },
+                "italics": {
+                    "1": "This is italicized.",
+                    "2": "This is also italicized."
+                },
+                "strike": "This is struck through."
+            }
+        }
     }
 }

--- a/app/i18n/enUS.json
+++ b/app/i18n/enUS.json
@@ -1,0 +1,37 @@
+{
+    "menu": {
+        "file": {
+            "label": "File",
+            "new": "New",
+            "open": "Open",
+            "save": "Save",
+            "saveAs": "Save As..."
+        },
+        "edit": {
+            "label": "Edit",
+            "undo": "Undo",
+            "redo": "Redo",
+            "cut": "Cut",
+            "copy": "Copy",
+            "paste": "Paste",
+            "selectAll": "Select All"
+        },
+        "view": {
+            "label": "View",
+            "reload": "Reload",
+            "forceReload": "Force Reload",
+            "devTools": "Toggle Developer Tools",
+            "theme": "Theme",
+            "setLanguage": "Set Language",
+            "actualSize": "Actual Size",
+            "zoomIn": "Zoom In",
+            "zoomOut": "Zoom Out",
+            "fullScreen": "Toggle Full Screen"
+        },
+        "help": {
+            "label": "Help",
+            "about": "About Markfast",
+            "markdownGuide": "Markdown Guide"
+        }
+    }
+}

--- a/app/i18n/igpay.json
+++ b/app/i18n/igpay.json
@@ -1,0 +1,37 @@
+{
+    "menu": {
+        "file": {
+            "label": "Ilefay",
+            "new": "Ewnay",
+            "open": "Openway",
+            "save": "Avesay",
+            "saveAs": "Avesay Asway..."
+        },
+        "edit": {
+            "label": "Editway",
+            "undo": "Undoway",
+            "redo": "Edoray",
+            "cut": "Utcay",
+            "copy": "Opycay",
+            "paste": "Astepay",
+            "selectAll": "Electsay Allway"
+        },
+        "view": {
+            "label": "Iewvay",
+            "reload": "Eloadray",
+            "forceReload": "Orcefay Eloadray",
+            "devTools": "Oggletay Eveloperday Oolstay",
+            "theme": "Emethay",
+            "setLanguage": "Etsay Anguagelay",
+            "actualSize": "Actualway Izesay",
+            "zoomIn": "Oomzay Inway",
+            "zoomOut": "Oomzay Outway",
+            "fullScreen": "Oggletay Ullfay Eenscray"
+        },
+        "help": {
+            "label": "Elphay",
+            "about": "Aboutway Arkfastmay",
+            "markdownGuide": "Arkdownmay Uidegay"
+        }
+    }
+}

--- a/app/i18n/igpay.json
+++ b/app/i18n/igpay.json
@@ -33,5 +33,10 @@
             "about": "Aboutway Arkfastmay",
             "markdownGuide": "Arkdownmay Uidegay"
         }
+    },
+    "langs": {
+        "enUS": "Americanway Englishway",
+        "igpay": "Igpay Atinlay",
+        "lolcat": "Olcatlay"
     }
 }

--- a/app/i18n/lolcat.json
+++ b/app/i18n/lolcat.json
@@ -33,5 +33,10 @@
             "about": "BOUT MARKFAST",
             "markdownGuide": "BOUT MARKDOWN"
         }
+    },
+    "langs": {
+        "enUS": "ENGLISH (UNITD STATEZ)",
+        "igpay": "PIG LATN",
+        "lolcat": "O HAI ITZ LOLCAT"
     }
 }

--- a/app/i18n/lolcat.json
+++ b/app/i18n/lolcat.json
@@ -1,0 +1,37 @@
+{
+    "menu": {
+        "file": {
+            "label": "FIEL",
+            "new": "NU",
+            "open": "OPEN FIEL",
+            "save": "SAVE DIS",
+            "saveAs": "SAVE DIS AS..."
+        },
+        "edit": {
+            "label": "EDITZ",
+            "undo": "UNDO DIS",
+            "redo": "REDO DIS",
+            "cut": "CUT DIS",
+            "copy": "COPY DIS",
+            "paste": "PASTE DIS",
+            "selectAll": "I CAN HAZ ALL?"
+        },
+        "view": {
+            "label": "VIEWZ",
+            "reload": "RELOAD DIS",
+            "forceReload": "RELOAD DIS!!1!",
+            "devTools": "I CAN HAZ DEV TOOLZ?",
+            "theme": "NU LOOKZ",
+            "setLanguage": "TRANSLASHUNZ",
+            "actualSize": "MAK AKSHUL SIEZ",
+            "zoomIn": "MAK BIGGR",
+            "zoomOut": "MAK SMALLR",
+            "fullScreen": "I CAN HAZ ALL SCREEN?"
+        },
+        "help": {
+            "label": "HALP PLZ",
+            "about": "BOUT MARKFAST",
+            "markdownGuide": "BOUT MARKDOWN"
+        }
+    }
+}

--- a/app/markdownGuide.html
+++ b/app/markdownGuide.html
@@ -13,6 +13,9 @@
             let config = new Config();
             const f1 = 112;
 
+            const _ = require('./i18n/_i18n');
+            function __(key) {document.write(_(key));}
+
             changeTheme(config.get('theme'));
 
             ipcRenderer.on('SWAP_THEME', (event, theme) => {
@@ -38,150 +41,150 @@
             }, false);
         </script>
 
-        <center><h1>Your Guide to Markdown</h1></center>
-        <div><center>
-            <a href="https://daringfireball.net/projects/markdown/" title="The official website of the Markdown language">Markdown</a>
-            is a markup language designed to be legible and easy to convert to HTML.
-            The Markfast editor is currently using the <a href="http://spec.commonmark.org/0.28/" title="CommonMark Spec Version 0.28">CommonMark Spec v0.28</a>.
-            The following is a guide to Markdown's syntax.
-        </center></div>
+        <center><h1><script>__('mdg::header')</script></h1></center>
+        <div><center><script>__('mdg::desc')</script></center></div>
         <hr/>
-        <h2 id="toc">Table of Contents</h2>
+        <h2 id="toc"><script>__('mdg::toc')</script></h2>
         <ul>
-            <li><a href="#inline-html">Inline HTML</a></li>
-            <li><a href="#headings">Headings</a></li>
-            <li><a href="#emphasis">Emphasis</a></li>
-            <li><a href="#lists">Lists</a></li>
-            <li><a href="#links">Links</a></li>
-            <li><a href="#images">Images</a></li>
+            <li><a href="#inline-html"><script>__('mdg::inlineHTML')</script></a></li>
+            <li><a href="#headings"><script>__('mdg::headings')</script></a></li>
+            <li><a href="#emphasis"><script>__('mdg::emphasis')</script></a></li>
+            <li><a href="#lists"><script>__('mdg::lists')</script></a></li>
+            <li><a href="#links"><script>__('mdg::links')</script></a></li>
+            <li><a href="#images"><script>__('mdg::images')</script></a></li>
         </ul>
         <hr/>
         <!-- INLINE HTML -->
-        <h2 id="inline-html">Inline HTML</h2>
-        <div>
+        <h2 id="inline-html"><script>__('mdg::inlineHTML')</script></h2>
+        <!-- <div>
             Inline HTML tags are parsed as HTML, meaning they can be used to structure a Markdown document.
             For instance, to format some text as inline code, you could use Markdown's native method of
             placing a backtick at each end of the inline code, or you could wrap the inline code in <code>&lt;code&gt;</code> tags.
-        </div>
+        </div> -->
+        <div><script>__('mdg::inlineHTML::desc')</script></div>
         <br/>
         <table style="width: 100%; font-size: smaller;">
             <tr>
-                <th>Markdown</th>
-                <th>Presentation</th>
-                <th>Hotkeys</th>
+                <th><script>__('mdg::markdown')</script></th>
+                <th><script>__('mdg::presentation')</script></th>
+                <th><script>__('mdg::hotkeys')</script></th>
             </tr>
             <tr>
-                <td><pre><code class="lang-md">`Inline code`</td>
-                <td><code>Inline code</code></td>
+                <td><pre><code class="lang-md">`<script>__('mdg::inlineHTML::sample')</script>`</td>
+                <td><code><script>__('mdg::inlineHTML::sample')</script></code></td>
                 <td></td>
             </tr>
             <tr>
-                <td><pre><code class="lang-html">&lt;code&gt;Inline code&lt;/code&gt;</td>
-                <td><code>Inline code</code></td>
+                <td><pre><code class="lang-html">&lt;code&gt;<script>__('mdg::inlineHTML::sample')</script>&lt;/code&gt;</td>
+                <td><code><script>__('mdg::inlineHTML::sample')</script></code></td>
                 <td></td>
             </tr>
         </table>
         <hr/>
         <!-- HEADINGS -->
-        <h2 id="headings">Headings</h2>
-        <div>
+        <h2 id="headings"><script>__('mdg::headings')</script></h2>
+        <!-- <div>
             To use HTML <code>h1</code>-<code>h6</code> headings, use pound signs at the start of the line.
             For instance, use <code>#</code> for <code>h1</code>, <code>##</code> for <code>h2</code>,
             and so forth up to <code>######</code> for <code>h6</code>.
+        </div> -->
+        <div>
+            <script>__('mdg::headings::desc')</script>
         </div>
         <br/>
         <table style="width: 100%; font-size: smaller;">
             <thead>
-                <th>Markdown</th>
-                <th>Presentation</th>
-                <th>Hotkeys</th>
+                <th><script>__('mdg::markdown')</script></th>
+                <th><script>__('mdg::presentation')</script></th>
+                <th><script>__('mdg::hotkeys')</script></th>
             </thead>
             <tr>
-                <td><pre><code class="lang-md"># Heading 1</td>
-                <td><h1 style="font-size: 125%;">Heading 1</h1></td>
+                <td><pre><code class="lang-md"># <script>__('mdg::headings::sample::1')</script></td>
+                <td><h1 style="font-size: 125%;"><script>__('mdg::headings::sample::1')</script></h1></td>
                 <td><kbd><script>document.write(config.get('cmdorctrl'))</script>1</kbd></td>
             </tr>
             <tr>
-                <td><pre><code class="lang-md">## Heading 2</td>
-                <td><h2 style="font-size: 115%;">Heading 2</h2></td>
+                <td><pre><code class="lang-md">## <script>__('mdg::headings::sample::2')</script></td>
+                <td><h2 style="font-size: 115%;"><script>__('mdg::headings::sample::2')</script></h2></td>
                 <td></td>
             </tr>
             <tr>
-                <td><pre><code class="lang-md">### Heading 3</td>
-                <td><h3 style="font-size: 105%;">Heading 3</h3></td>
+                <td><pre><code class="lang-md">### <script>__('mdg::headings::sample::3')</script></td>
+                <td><h3 style="font-size: 105%;"><script>__('mdg::headings::sample::3')</script></h3></td>
                 <td></td>
             </tr>
             <tr>
-                <td><pre><code class="lang-md">#### Heading 4</td>
-                <td><h4 style="font-size: 95%;">Heading 4</h4></td>
+                <td><pre><code class="lang-md">#### <script>__('mdg::headings::sample::4')</script></td>
+                <td><h4 style="font-size: 95%;"><script>__('mdg::headings::sample::4')</script></h4></td>
                 <td></td>
             </tr>
             <tr>
-                <td><pre><code class="lang-md">##### Heading 5</td>
-                <td><h5 style="font-size: 85%;">Heading 5</h5></td>
+                <td><pre><code class="lang-md">##### <script>__('mdg::headings::sample::5')</script></td>
+                <td><h5 style="font-size: 85%;"><script>__('mdg::headings::sample::5')</script></h5></td>
                 <td></td>
             </tr>
             <tr>
-                <td><pre><code class="lang-md">###### Heading 6</td>
-                <td><h6 style="font-size: 75%;">Heading 6</h6></td>
+                <td><pre><code class="lang-md">###### <script>__('mdg::headings::sample::6')</script></td>
+                <td><h6 style="font-size: 75%;"><script>__('mdg::headings::sample::6')</script></h6></td>
                 <td></td>
             </tr>
         </table>
         <hr/>
         <!-- EMPHASIS -->
-        <h2 id="emphasis">Emphasis</h2>
-        <div>
+        <h2 id="emphasis"><script>__('mdg::emphasis')</script></h2>
+        <!-- <div>
             Markdown supports bolding, italicizing, and strikethrough.
             Any of these can be used in tandem with each other.
-        </div>
+        </div> -->
+        <div><script>__('mdg::emphasis::desc')</script></div>
         <br/>
         <table style="width: 100%; font-size: smaller;">
             <thead>
-                <th>Markdown</th>
-                <th>Presentation</th>
-                <th>Hotkeys</th>
+                <th><script>__('mdg::markdown')</script></th>
+                <th><script>__('mdg::presentation')</script></th>
+                <th><script>__('mdg::hotkeys')</script></th>
             </thead>
             <tr>
                 <td>
-                    <pre><code class="lang-md">**This is bold.**</code></pre>
-                    <pre><code class="lang-md">__This is also bold.__</code></pre>
+                    <pre><code class="lang-md">**<script>__('mdg::emphasis::sample::bold::1')</script>**</code></pre>
+                    <pre><code class="lang-md">__<script>__('mdg::emphasis::sample::bold::2')</script>__</code></pre>
                 </td>
                 <td><strong>
-                    This is bold.<br/>
-                    This is also bold.
+                    <script>__('mdg::emphasis::sample::bold::1')</script><br/>
+                    <script>__('mdg::emphasis::sample::bold::2')</script>
                 </strong></td>
                 <td><kbd><script>document.write(config.get('cmdorctrl'))</script>B</kbd></td>
             </tr>
             <tr>
                 <td>
-                    <pre><code class="lang-md">*This is italicized.*</code></pre>
-                    <pre><code class="lang-md">_This is also italicized._</code></pre>
+                    <pre><code class="lang-md">*<script>__('mdg::emphasis::sample::italics::1')</script>*</code></pre>
+                    <pre><code class="lang-md">_<script>__('mdg::emphasis::sample::italics::2')</script>_</code></pre>
                 </td>
                 <td><em>
-                    This is italicized.<br/>
-                    This is also italicized.
+                    <script>__('mdg::emphasis::sample::italics::1')</script><br/>
+                    <script>__('mdg::emphasis::sample::italics::2')</script>
                 </em></td>
                 <td><kbd><script>document.write(config.get('cmdorctrl'))</script>I</kbd></td>
             </tr>
             <tr>
                 <td>
-                    <pre><code class="lang-md">~~This is struck through.~~</code></pre>
+                    <pre><code class="lang-md">~~<script>__('mdg::emphasis::sample::strike')</script>~~</code></pre>
                 </td>
                 <td><strike>
-                    This is struck through.
+                    <script>__('mdg::emphasis::sample::strike')</script>
                 </strike></td>
                 <td></td>
             </tr>
         </table>
         <hr/>
         <!-- LISTS -->
-        <h2 id="lists">Lists</h2>
+        <h2 id="lists"><script>__('mdg::lists')</script></h2>
         <hr/>
         <!-- LINKS -->
-        <h2 id="links">Links</h2>
+        <h2 id="links"><script>__('mdg::links')</script></h2>
         <hr/>
         <!-- IMAGES -->
-        <h2 id="images">Images</h2>
+        <h2 id="images"><script>__('mdg::images')</script></h2>
         <hr/>
     </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -4,9 +4,8 @@ const Config = require('electron-config');
 const fs = require('fs');
 const {assignMenu, swapTheme} = require('./app/MenuHelper');
 const EditorWindow = require('./app/EditorWindow');
-const MarkdownGuideWindow = require('./app/MarkdownGuideWindow');
 
-let mainWindow, markdownGuide;
+let mainWindow;
 global.windows = [];
 let config = new Config();
 
@@ -101,26 +100,6 @@ function saveAs() {
             fs.writeFile(filename, con, (error) => {console.log(error)});
         })
     });
-}
-
-/**
- * Opens the Markdown Guide window.
- * Opens a new guide window if none are open, or reshows the guide window if it's already open.
- */
-function openMarkdownGuide() {
-    if(markdownGuide == null) {
-        markdownGuide = new MarkdownGuideWindow();
-        markdownGuide.on('close', () => {
-            markdownGuide = null;
-            global.windows.splice(global.windows.indexOf(markdownGuide), 1);
-        })
-        markdownGuide.setMenu(null);
-        global.windows.push(markdownGuide);
-    }
-    else {
-        markdownGuide.webContents.reloadIgnoringCache();
-        markdownGuide.show();
-    }
 }
 
 if(process.platform === 'darwin') {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ const fs = require('fs');
 const {assignMenu, swapTheme} = require('./app/MenuHelper');
 const EditorWindow = require('./app/EditorWindow');
 
-let mainWindow;
 global.windows = [];
 let config = new Config();
 
@@ -28,8 +27,8 @@ app.on('ready', () => {
     }
 
     // INITIALIZE WINDOW
-    mainWindow = new EditorWindow();
-    mainWindow.on('close', () => {app.quit();})
+    global.mainWindow = new EditorWindow();
+    global.mainWindow.on('close', () => {app.quit();})
     global.windows.push(mainWindow);
     swapTheme(config.get('theme'));
     assignMenu();
@@ -40,7 +39,7 @@ app.on('ready', () => {
  * Clears editor and removes current file from config.
  */
 function newFile() {
-    mainWindow.webContents.send('SET_EDITOR_CONTENTS', '');
+    global.mainWindow.webContents.send('SET_EDITOR_CONTENTS', '');
     config.delete('openfile')
 }
 
@@ -59,7 +58,7 @@ function openFile() {
         if(filenames === undefined) return;
         config.set('openfile', filenames[0]);
         let content = fs.readFile(filenames[0], 'utf-8', (err, data) => {
-            mainWindow.webContents.send('SET_EDITOR_CONTENTS', data);
+            global.mainWindow.webContents.send('SET_EDITOR_CONTENTS', data);
             loadDirectory(path.join(filenames[0], '..'));
         })
     });
@@ -74,7 +73,7 @@ function save() {
         saveAs();
     }
     else {
-        mainWindow.webContents.send('GET_EDITOR_CONTENTS');
+        global.mainWindow.webContents.send('GET_EDITOR_CONTENTS');
         ipcMain.once('GET_EDITOR_CONTENTS2', (event, con) => {
             fs.writeFile(config.get('openfile'), con, (error) => {console.log(error)});
         });
@@ -95,13 +94,9 @@ function saveAs() {
     }, filename => {
         if(filename === undefined) return;
         config.set('openfile', filename);
-        mainWindow.webContents.send('GET_EDITOR_CONTENTS');
+        global.mainWindow.webContents.send('GET_EDITOR_CONTENTS');
         ipcMain.once('GET_EDITOR_CONTENTS2', (event, con) => {
             fs.writeFile(filename, con, (error) => {console.log(error)});
         })
     });
-}
-
-if(process.platform === 'darwin') {
-    menuTemplate.unshift({});
 }


### PR DESCRIPTION
Introduced internationalization & localization functionality by way of the `_` module from `app/i18n/_i18n.js`.

## Localization JSON Files

Languages are each specified in their own JSON file inside of `app/i18n/`. Natural languages' JSON files should be named as follows:

### `<lang_code>[<GEOGRAPHIC_VARIANT>].json`

- **`<lang_code>`** - Where possible, this should be the language's two-letter [ISO 639-1 language code.](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) If a natural language does not have an ISO 639-1 language code but *does* have a three-letter [ISO 639-2 code](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes), that should be used instead.

- **`<GEOGRAPHIC_VARIANT>`** *(optional)* - Where multiple variants or dialects of a language could be included, a two-letter geographic designator of the dialect should be included. Preferably, this should align with the [ISO 3166-1 alpha-2 codes](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) where possible.

For example, an Italian localization JSON would be named `it.json`, and the American English localization JSON is named `enUS.json`.

As `enUS.json` is likely to be the best implemented language, contributors looking to translate Markfast into their own languages should use `enUS.json` as the standard to go by.

## Importing & Injecting Localizations

To import the internationalization module in a JavaScript file within the Markfast project, require `/app/i18n/_i18n`. As of this pull request, the internationalization function `_()` is `_i18n.js`'s only export, but this *may* change down the road.

By project convention, this function should be imported as `_()`. This is to keep calls to this localization function terse, as they could be very frequent.

If `_()` is being imported into the script tags of an HTML document, it is recommended that the following wrapper function be included to keep localization injection terse:

```html
function __(key) {
    document.write(_(key));
}
```

Notice that this wrapper function should be named with *two* underscores, as opposed to the imported single-underscore localization function.

## Localization Keys

Calls to the `_()` localization function take a `key` parameter. This key aligns with the specificity of the language JSON file. Each step of specificity is delineated with two colons, `::`.

For instance, let us suppose this is our language JSON file.

```json
{
    "menu": {
        "file": {
            "label": "File",
            "new": "New",
            "open": "Open",
            "save": "Save",
            "saveAs": "Save As..."
        },
        "edit": {
            "label": "Edit",
            "undo": "Undo",
            "redo": "Redo",
            "cut": "Cut",
            "copy": "Copy",
            "paste": "Paste",
            "selectAll": "Select All"
        }
    }
}
```

A key of `'menu::file::new'` will look inside the language's `menu` object, then inside `menu`'s `file` object, and then at `new`. This would correspond to a JavaScript call to `lang.menu.file.new`.

If your key finds an object instead of a value, then the localization function will return that object's `label` property. For instance, a key of `'menu::edit'` will return `lang.menu.edit.label`, or `"Edit"`.

If no localization is found at that key, the localization function will fall back to the English (US) localization at that key or, failing that, the most specific token of the key itself.